### PR TITLE
Update for DS contact email addresses

### DIFF
--- a/en/about.md
+++ b/en/about.md
@@ -21,7 +21,7 @@ The rights statements are not just about the making things easier for the user. 
 
 ## A collaborative approach to governance which ensures the consortium meets the needs of the cultural heritage sector
 
-The rightsstatements.org consortium is currently hosted by Europeana and overseen by an interim Governance Committee.
+The rightsstatements.org consortium is currently hosted by Digital Scholar and overseen by an Interim Steering Committee.
 
 Members of the interim Governance Committee:
 * Emily Gore

--- a/en/documentation/translations.md
+++ b/en/documentation/translations.md
@@ -7,7 +7,7 @@ filename: translations
 ---
 # Translations of the rights statements
 
-The rights statements and underlying infrastructure of rightsstatements.org have been designed to work internationally in many languages. If you are interested in working with us on translating the rights statements please contact us at [copyright@europeana.eu](mailto:copyright@europeana.eu). Translations of the rights statements need to be produced in line with our [translation policy]({{site.url}}/en/documentation/translation-policy/) which you can find on our [Documentation]({{site.url}}/en/documentation/) page.
+The rights statements and underlying infrastructure of rightsstatements.org have been designed to work internationally in many languages. If you are interested in working with us on translating the rights statements please contact us at [rs-translations@digitalscholar.org](mailto:rs-translations@digitalscholar.org). Translations of the rights statements need to be produced in line with our [translation policy]({{site.url}}/en/documentation/translation-policy/) which you can find on our [Documentation]({{site.url}}/en/documentation/) page.
 
 <div class="box">
 
@@ -32,7 +32,7 @@ The rights statements have been translated into the following languages:
 ## Translations under public review
 
 As described in our [translation policy]({{site.url}}/en/documentation/translation-policy/), every draft translation is published for a public comment period of 4
-weeks. If you wish to review a draft translation, please contact us at [copyright@europeana.eu](mailto:copyright@europeana.eu) indicating the language that you wish to review.
+weeks. If you wish to review a draft translation, please contact us at [rs-translations@digitalscholar.org](mailto:rs-translations@digitalscholar.org) indicating the language that you wish to review.
 
 We will give you access to the system we use for this purpose so that you can complete your revision. The feedback from the public comment period will be addressed by the translation partner together with the reviewer(s).
 

--- a/en/get_involved.md
+++ b/en/get_involved.md
@@ -8,7 +8,7 @@ lang: en
 
 # Get Involved
 
-RightsStatements.org provides a set of standardized rights statements that answers the needs of cultural heritage institutions and aggregators across the globe. If you are interested in joining the consortium, contributing to the development of the rights statements we offer, or if you have questions, please get in touch with us [copyright@europeana.eu](mailto:copyright@europeana.eu).
+RightsStatements.org provides a set of standardized rights statements that answers the needs of cultural heritage institutions and aggregators across the globe. If you are interested in joining the consortium, contributing to the development of the rights statements we offer, or if you have questions, please get in touch with us [rights-statements@digitalscholar.org](mailto:rights-statements@digitalscholar.org).
 
 ### Find out how to use the rights statement in your organisation
 
@@ -20,7 +20,7 @@ RightsStatements.org provides a set of standardized rights statements that answe
 
 ### Keep up to date on the latest news
 
-If you're interested in finding out more information about membership of the consortium or the working groups, or have any other questions please [contact us](mailto:copyright@europeana.eu).
+If you're interested in finding out more information about membership of the consortium or the working groups, or have any other questions please [contact us](mailto:rights-statements@digitalscholar.org).
 
 [documentation]: {{site.url}}/en/documentation/
 [translations]: {{site.url}}/en/documentation/translations.html


### PR DESCRIPTION
These updates replace the contact email address, name DS as the host on the about page, and add a new email address specifically for translation work.